### PR TITLE
Feature: add workers and queue

### DIFF
--- a/app/Events/ProcessDuplicationEvent.php
+++ b/app/Events/ProcessDuplicationEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Node;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessDuplicationEvent
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(private readonly int $nodeId){}
+
+    public function getNodeId(): int
+    {
+        return $this->nodeId;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/app/Jobs/DuplicateNodeJob.php
+++ b/app/Jobs/DuplicateNodeJob.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Node;
+use App\Services\DuplicationService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+
+class DuplicateNodeJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * @param Node $node
+     * @param int|null $parentId
+     */
+    public function __construct(private readonly Node $node, private readonly ?int $parentId) {}
+
+    /**
+     * @param DuplicationService $duplicationService
+     * @return void
+     */
+    public function handle(DuplicationService $duplicationService): void
+    {
+        $duplicationService->duplicate($this->node, $this->parentId);
+    }
+}

--- a/app/Listeners/ProcessDuplicationListener.php
+++ b/app/Listeners/ProcessDuplicationListener.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\ProcessDuplicationEvent;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ProcessDuplicationListener
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct(){}
+
+    /**
+     * Handle the event.
+     */
+    public function handle(ProcessDuplicationEvent $event): void
+    {
+
+        $nodeId = $event->getNodeId();
+        // register the log of node
+        Log::channel('duplication')->info('Node duplicated successfully', [
+            'node_id' => $nodeId,
+            'timestamp' => now(),
+        ]);
+    }
+}

--- a/config/logging.php
+++ b/config/logging.php
@@ -127,6 +127,11 @@ return [
             'path' => storage_path('logs/laravel.log'),
         ],
 
+        'duplication' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/duplication.log'),
+            'level' => 'info',
+        ],
     ],
 
 ];


### PR DESCRIPTION
What?
Add task queues to handle asynchronous jobs.

Why?
When there is duplication of content within the application, there may be cases where there are many interactions with the database and also processing. This high load of iterations may take longer than expected, making it necessary to find an alternative in which the processing is done asynchronously so as not to crash the application.